### PR TITLE
[DEV-9930] Add a Flake8 rule for not allowing imports from models subpackages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# idea files
+.idea

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         language_version: python3.8
 
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -31,6 +31,7 @@ ROU104 = "ROU104 Multiple blank lines are not allowed after a non-section commen
 ROU105 = "ROU105 Constants are not in order"
 ROU106 = "ROU106 Relative imports are not allowed"
 ROU107 = "ROU107 Inline function import is not at top of statement"
+ROU108 = "ROU108 Import for model module instead of sub-packages"
 
 
 @dataclass
@@ -152,6 +153,10 @@ class Visitor(ast.NodeVisitor):
 
         if node.level > 0:
             self.errors.append((node.lineno, node.col_offset, ROU106))
+
+        print(node.module)
+        if node.module is not None and "models." in node.module:
+            self.errors.append((node.lineno, node.col_offset, ROU108))
 
     def visit_Set(self, node: ast.Set) -> None:
         if not self._is_ordered(node.elts):

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -31,7 +31,7 @@ ROU104 = "ROU104 Multiple blank lines are not allowed after a non-section commen
 ROU105 = "ROU105 Constants are not in order"
 ROU106 = "ROU106 Relative imports are not allowed"
 ROU107 = "ROU107 Inline function import is not at top of statement"
-ROU108 = "ROU108 Import for model module instead of sub-packages"
+ROU108 = "ROU108 Import from model module instead of sub-packages"
 
 
 @dataclass
@@ -154,7 +154,6 @@ class Visitor(ast.NodeVisitor):
         if node.level > 0:
             self.errors.append((node.lineno, node.col_offset, ROU106))
 
-        print(node.module)
         if node.module is not None and "models." in node.module:
             self.errors.append((node.lineno, node.col_offset, ROU108))
 

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -154,7 +154,7 @@ class Visitor(ast.NodeVisitor):
         if node.level > 0:
             self.errors.append((node.lineno, node.col_offset, ROU106))
 
-        if node.module is not None and "models." in node.module:
+        if node.module is not None and ".models." in node.module:
             self.errors.append((node.lineno, node.col_offset, ROU108))
 
     def visit_Set(self, node: ast.Set) -> None:

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -488,6 +488,20 @@ class TestROU107:
         assert error == set()
 
 
+class TestROU108:
+    def test_non_model_subpackage_import(self):
+        error = results("from app.constants.subpackage import ModelA, ModelB")
+        assert error == set()
+
+    def test_model_subpackage_import(self):
+        error = results("from app.models.subpackage import ModelA, ModelB")
+        assert error == {"1:0: ROU108 Import for model module instead of sub-packages"}
+
+    def test_model_module_import(self):
+        error = results("from app.models import Model")
+        assert error == set()
+
+
 class TestVisitor:
     def test_parse_to_string_warning(self):
         visitor = Visitor()

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -495,7 +495,7 @@ class TestROU108:
 
     def test_model_subpackage_import(self):
         error = results("from app.models.subpackage import ModelA, ModelB")
-        assert error == {"1:0: ROU108 Import for model module instead of sub-packages"}
+        assert error == {"1:0: ROU108 Import from model module instead of sub-packages"}
 
     def test_model_module_import(self):
         error = results("from app.models import Model")

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -493,6 +493,10 @@ class TestROU108:
         error = results("from app.constants.subpackage import ModelA, ModelB")
         assert error == set()
 
+    def test_non_model_named_like_a_model_subpackage_import(self):
+        error = results("from app.like_a_model.subpackage import ModelA, ModelB")
+        assert error == set()
+
     def test_model_subpackage_import(self):
         error = results("from app.models.subpackage import ModelA, ModelB")
         assert error == {"1:0: ROU108 Import from model module instead of sub-packages"}


### PR DESCRIPTION
This PR adds a new (proposed) lint rule to ensure models are imported from the module, rather than sub-packages.
It also fixes the good ol' flake8 to pre-commit hook to use the current github repo vs the old gitlab one.

Details:
(feat) add lint rule to ensure model imports are done from the module and not subpackages
(test) add tests to ensure new rule works as intended
(misc) add .idea to gitignore
(fix) update flake8 repo from gitlab to github