### PR TITLE
[DEV-12543] Add rule for disallowing migration renames 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: check-json
       - id: check-yaml
@@ -12,32 +12,32 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v3.8.0
     hooks:
       - id: pyupgrade
         args: ['--py38-plus', '--keep-mock']
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies:
           - 'toml'
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         args: ['--add-ignore=D100,D101,D102,D103,D104,D105,D106,D107,D205,D400,D401']
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         language_version: python3.8
 
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -32,6 +32,7 @@ ROU105 = "ROU105 Constants are not in order"
 ROU106 = "ROU106 Relative imports are not allowed"
 ROU107 = "ROU107 Inline function import is not at top of statement"
 ROU108 = "ROU108 Import from model module instead of sub-packages"
+ROU109 = "ROU109 Disallow rename migrations"
 
 
 @dataclass
@@ -176,6 +177,7 @@ class FileTokenHelper:
         self.lines_with_blank_lines_after_comments()
         self.lines_with_invalid_docstrings()
         self.lines_with_invalid_multi_line_strings()
+        self.rename_migrations()
 
     def lines_with_blank_lines_after_comments(self) -> None:
         """
@@ -329,6 +331,20 @@ class FileTokenHelper:
 
             # grouped tokens will no longer be a comment's prefix if they aren't new lines or indents (earlier clause)
             is_whitespace_prefix = False
+
+    def rename_migrations(self) -> None:
+        """Migrations should not allow renames."""
+        reported = set()
+        disallowed_migration_text = "migrations.RenameField"
+
+        for line_token in self._file_tokens:
+            if line_token.start[0] in reported:
+                # There could be many tokens on a same line.
+                continue
+
+            if disallowed_migration_text in line_token.line:
+                reported.add(line_token.start[0])
+                self.errors.append((*line_token.start, ROU109))
 
 
 class Plugin:

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -297,7 +297,7 @@ class FileTokenHelper:
         # last line number of the last statement (in case it spans multiple lines)
         last_stmt_line_no = None
 
-        for (token_type, token_str, start_indices, end_indices, line) in self._file_tokens:
+        for token_type, token_str, start_indices, end_indices, line in self._file_tokens:
             line_no = start_indices[0]
 
             if token_type in (tokenize.DEDENT, tokenize.INDENT, tokenize.NEWLINE, tokenize.NL):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = flake8_routable
-version = 0.1.0
+version = 0.1.1
 
 [options]
 py_modules = flake8_routable

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = flake8_routable
-version = 0.1.1
+version = 0.1.2
 
 [options]
 py_modules = flake8_routable

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -507,8 +507,7 @@ class TestROU108:
 
 
 class TestROU109:
-    ADD_MIGRATION = (
-    """class Migration(migrations.Migration):
+    ADD_MIGRATION = """class Migration(migrations.Migration):
         dependencies = []
         operations = [
             migrations.AddField(
@@ -517,10 +516,8 @@ class TestROU109:
                 field=models.TextField(blank=True, null=True),
             )
         ]"""
-    )
 
-    RENAME_MIGRATION = (
-    """class Migration(migrations.Migration):
+    RENAME_MIGRATION = """class Migration(migrations.Migration):
         dependencies = []
         operations = [
             migrations.RenameField(
@@ -529,7 +526,6 @@ class TestROU109:
                 new="field_two",
             )
         ]"""
-    )
 
     def test_correct_no_import_from_tests(self):
         errors = results(self.ADD_MIGRATION)

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -506,6 +506,40 @@ class TestROU108:
         assert error == set()
 
 
+class TestROU109:
+    ADD_MIGRATION = (
+    """class Migration(migrations.Migration):
+        dependencies = []
+        operations = [
+            migrations.AddField(
+                model_name="model_one",
+                name="swift_charge_option",
+                field=models.TextField(blank=True, null=True),
+            )
+        ]"""
+    )
+
+    RENAME_MIGRATION = (
+    """class Migration(migrations.Migration):
+        dependencies = []
+        operations = [
+            migrations.RenameField(
+                model_name="model_one",
+                old="field_one",
+                new="field_two",
+            )
+        ]"""
+    )
+
+    def test_correct_no_import_from_tests(self):
+        errors = results(self.ADD_MIGRATION)
+        assert errors == set()
+
+    def test_incorrect_import_from_tests(self):
+        errors = results(self.RENAME_MIGRATION)
+        assert errors == {"4:12: ROU109 Disallow rename migrations"}
+
+
 class TestVisitor:
     def test_parse_to_string_warning(self):
         visitor = Visitor()


### PR DESCRIPTION
@matthew-scott-routable and I were talking about helping our team avoid incidents like INCD-32, and we opted to add a lint rule that would disallow the use of field rename migrations to avoid service interruptions of 0 downtime deploys.

This was the easiest way forward and one that allows developers to override it if needs be.