### PR TITLE
[DEV-12547] - Fix ROU108 lint issues

### DIFF
--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -1,4 +1,5 @@
 # Python imports
+import abc
 import ast
 import importlib.metadata as importlib_metadata
 import tokenize
@@ -66,7 +67,40 @@ class BlankLinesAfterCommentConditions:
         )
 
 
-class Visitor(ast.NodeVisitor):
+class ImportVisitor(abc.ABC):
+    """Base class for checking imports with Flake8."""
+
+    def _check_relative_import(self, node: ast.ImportFrom):
+        """ROU106 - Relative imports are not allowed."""
+        if node.level > 0:
+            self.errors.append((node.lineno, node.col_offset, ROU106))
+
+    def _check_imports_from_tests(self, node: ast.ImportFrom):
+        """ROU101 - Import from a tests directory."""
+        if not node.module:
+            return
+
+        if "tests" in node.module:
+            self.errors.append((node.lineno, node.col_offset, ROU101))
+
+    def _check_subpackage_model_imports(self, node: ast.ImportFrom):
+        """ROU108 - Import from model module instead of sub-packages."""
+        if not node.module:
+            return
+
+        if node.module.startswith("django"):
+            return
+
+        if ".models." in node.module:
+            self.errors.append((node.lineno, node.col_offset, ROU108))
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        self._check_relative_import(node)
+        self._check_imports_from_tests(node)
+        self._check_subpackage_model_imports(node)
+
+
+class Visitor(ImportVisitor, ast.NodeVisitor):
     """Linting errors that use the AST."""
 
     def __init__(self) -> None:
@@ -147,16 +181,6 @@ class Visitor(ast.NodeVisitor):
                     self.errors.append((body_node.lineno, body_node.col_offset, ROU107))
             else:
                 has_non_docstring_before_import = True
-
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        if node.module is not None and "tests" in node.module:
-            self.errors.append((node.lineno, node.col_offset, ROU101))
-
-        if node.level > 0:
-            self.errors.append((node.lineno, node.col_offset, ROU106))
-
-        if node.module is not None and ".models." in node.module:
-            self.errors.append((node.lineno, node.col_offset, ROU108))
 
     def visit_Set(self, node: ast.Set) -> None:
         if not self._is_ordered(node.elts):

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -497,6 +497,10 @@ class TestROU108:
         error = results("from app.like_a_model.subpackage import ModelA, ModelB")
         assert error == set()
 
+    def test_django_model_subpackage_import_allowed(self):
+        error = results("from django.db.models.manager import RelatedManager")
+        assert error == set()
+
     def test_model_subpackage_import(self):
         error = results("from app.models.subpackage import ModelA, ModelB")
         assert error == {"1:0: ROU108 Import from model module instead of sub-packages"}


### PR DESCRIPTION
As a follow up to https://github.com/routablehq/flake8-routable/pull/16 we needed to exclude ROU108 lint issues for Django imports, as those should be allowed.