### PR TITLE
[ROU110] - Add a new rule for disallowing .save() without update fields or comments justifying it

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Here is a list of the rules supported by this Flake8 plugin:
 * `ROU107` - Inline function import is not at top of statement
 * `ROU108` - Import from model module instead of sub-packages
 * `ROU109` - Disallow rename migrations
+* `ROU110` - Disallow .save() with no update_fields
 * `ROU111` - Disallow FeatureFlag creation in code
 
 ## Testing

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -365,7 +365,7 @@ class FileTokenHelper:
                 # Skip lines that aren't a single line .save()
                 continue
 
-            if "update_fields=" in line:
+            if "update_fields" in line:
                 # One line save, with update_fields is allowed
                 continue
 

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -354,30 +354,32 @@ class FileTokenHelper:
     def disallow_no_update_fields_save(self) -> None:
         """.save() must be called with update_fields."""
         reported = set()
-        single_line_save = re.compile(r".+(\.save\(.*)\)")
+        single_line_save = re.compile(r".+(\.save\(.*)")
         allowed_comments = [
-            "# new model save",
-            "# serializer save",
-            "# save extension",
-            "# ledger save",
-            "# file save",
-            "# not a model",
             "# TODO: needs fix",
+            "# file save",
+            "# form save",
+            "# ledger save",
+            "# multiline with update_fields",
+            "# new model save",
+            "# not a model",
+            "# save extension",
+            "# serializer save",
         ]
 
         for line_token in self._file_tokens:
-            if line_token.start[0] in reported:  # TODO: what does this mean?
+            if line_token.start[0] in reported:
                 # There could be many tokens on a same line.
                 continue
 
             line = line_token.line
 
             if not single_line_save.match(line):
-                # Skip lines that aren't a single line .save()
+                # Skip lines that don't match
                 continue
 
             if "update_fields" in line:
-                # One line save, with update_fields is allowed
+                # save, with update_fields is allowed
                 continue
 
             if any(comment in line for comment in allowed_comments):
@@ -390,7 +392,7 @@ class FileTokenHelper:
     def disallow_feature_flag_creation(self) -> None:
         """We can not create FeatureFlags in code, they are cached on the request."""
         reported = set()
-        feature_flag_creation = re.compile(r".+(FeatureFlag\.objects\..*create)")
+        feature_flag_creation = re.compile(r"^.*?(FeatureFlag\.objects\..*create)")
         allowed_comments = [
             "# valid for legacy cross-border work",
             "# valid for management command",

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -353,6 +353,15 @@ class FileTokenHelper:
         """.save() must be called with update_fields."""
         reported = set()
         single_line_save = re.compile(r".+(\.save\(.*)\)")
+        allowed_comments = [
+            "# new model save",
+            "# serializer save",
+            "# save extension",
+            "# ledger save",
+            "# file save",
+            "# not a model",
+            "# TODO: needs fix",
+        ]
 
         for line_token in self._file_tokens:
             if line_token.start[0] in reported:  # TODO: what does this mean?
@@ -369,7 +378,7 @@ class FileTokenHelper:
                 # One line save, with update_fields is allowed
                 continue
 
-            if "# new model save" in line or "# serializer save" in line:
+            if any(comment in line for comment in allowed_comments):
                 # Ignore lines with these comments, as they are valid
                 continue
 

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -360,7 +360,7 @@ class FileTokenHelper:
             "# file save",
             "# form save",
             "# ledger save",
-            "# multiline with update_fields",
+            "# multi-line with update_fields",
             "# new model save",
             "# not a model",
             "# save extension",

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -396,7 +396,6 @@ class FileTokenHelper:
         allowed_comments = [
             "# valid for legacy cross-border work",
             "# valid for management command",
-            "# valid for test usage",
         ]
 
         for line_token in self._file_tokens:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = flake8_routable
-version = 0.1.3
+version = 0.1.4
 
 [options]
 py_modules = flake8_routable

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -544,7 +544,7 @@ instance.save(update_fields=["id", "name"])
 
     SAVE_MULTILINE_WITH_UPDATE_FIELDS_FLAG = """from app.models import Model
 instance = Model(id="123", name="test")
-instance.save(  # multiline with update_fields
+instance.save(  # multi-line with update_fields
     update_fields=["id", "name"]
 )
 """

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -548,14 +548,9 @@ instance.save()
 instance.save(using="default")
 """
 
-    SAVE_WITH_NEW_MODEL_SAVE_COMMENT = """from app.models import Model
+    SAVE_WITH_COMMENT = """from app.models import Model
 instance = Model(id="123", name="test")
-instance.save()  # new model save
-"""
-
-    SAVE_WITH_SERIALIZER_SAVE_COMMENT = """from app.models import Model
-instance = Model(id="123", name="test")
-instance.save()  # serializer save
+instance.save()  # {comment}
 """
 
     def test_save_with_update_fields(self):
@@ -569,12 +564,20 @@ instance.save()  # serializer save
             "4:0: ROU110 Disallow .save() with no update_fields",
         }
 
-    def test_new_model_save_with_comment(self):
-        errors = results(self.SAVE_WITH_NEW_MODEL_SAVE_COMMENT)
-        assert errors == set()
-
-    def test_serializer_save_with_comment(self):
-        errors = results(self.SAVE_WITH_SERIALIZER_SAVE_COMMENT)
+    @pytest.mark.parametrize(
+        "comment",
+        [
+            "# new model save",
+            "# serializer save",
+            "# save extension",
+            "# ledger save",
+            "# file save",
+            "# not a model",
+            "# TODO: needs fix",
+        ],
+    )
+    def test_with_comment(self, comment):
+        errors = results(self.SAVE_WITH_COMMENT.format(comment=comment))
         assert errors == set()
 
 

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -542,6 +542,13 @@ instance = Model(id="123", name="test")
 instance.save(update_fields=["id", "name"])
 """
 
+    SAVE_MULTILINE_WITH_UPDATE_FIELDS_FLAG = """from app.models import Model
+instance = Model(id="123", name="test")
+instance.save(  # multiline with update_fields
+    update_fields=["id", "name"]
+)
+"""
+
     SAVE_WITHOUT_UPDATE_FIELDS = """from app.models import Model
 instance = Model(id="123", name="test")
 instance.save()
@@ -550,11 +557,15 @@ instance.save(using="default")
 
     SAVE_WITH_COMMENT = """from app.models import Model
 instance = Model(id="123", name="test")
-instance.save()  # {comment}
+instance.save()  {comment}
 """
 
     def test_save_with_update_fields(self):
         errors = results(self.SAVE_WITH_UPDATE_FIELDS)
+        assert errors == set()
+
+    def test_save__multiline_with_update_fields_flag(self):
+        errors = results(self.SAVE_MULTILINE_WITH_UPDATE_FIELDS_FLAG)
         assert errors == set()
 
     def test_save_without_update_fields(self):
@@ -567,18 +578,85 @@ instance.save()  # {comment}
     @pytest.mark.parametrize(
         "comment",
         [
-            "# new model save",
-            "# serializer save",
-            "# save extension",
-            "# ledger save",
-            "# file save",
-            "# not a model",
             "# TODO: needs fix",
+            "# file save",
+            "# form save",
+            "# ledger save",
+            "# new model save",
+            "# not a model",
+            "# save extension",
+            "# serializer save",
         ],
     )
     def test_with_comment(self, comment):
         errors = results(self.SAVE_WITH_COMMENT.format(comment=comment))
         assert errors == set()
+
+
+class TestROU111:
+    FEATURE_FLAG_CREATE = """from feature_config.models import FeatureFlag
+FeatureFlag.objects.create(company=company, feature_flag=flag)
+"""
+
+    FEATURE_FLAG_CREATE_MULTILINE = """from feature_config.models import FeatureFlag
+FeatureFlag.objects.create(
+    company=company, feature_flag=flag
+)
+"""
+
+    FEATURE_FLAG_GET_OR_CREATE = """from feature_config.models import FeatureFlag
+def method():
+    FeatureFlag.objects.get_or_create(company=company, feature_flag=flag)
+"""
+
+    FEATURE_FLAG_WITH_COMMENT = """from feature_config.models import FeatureFlag
+FeatureFlag.objects.create(  {comment}
+    company=company, feature_flag=flag
+)
+"""
+
+    def test_feature_flag_create(self):
+        errors = results(self.FEATURE_FLAG_CREATE)
+        assert errors == {
+            "2:0: ROU111 Disallow FeatureFlag creation in code",
+        }
+
+    def test_feature_flag_create_multiline(self):
+        errors = results(self.FEATURE_FLAG_CREATE_MULTILINE)
+        assert errors == {
+            "2:0: ROU111 Disallow FeatureFlag creation in code",
+        }
+
+    def test_feature_flag_get_or_create(self):
+        errors = results(self.FEATURE_FLAG_GET_OR_CREATE)
+        assert errors == {
+            "3:0: ROU111 Disallow FeatureFlag creation in code",
+        }
+
+    @pytest.mark.parametrize(
+        "comment",
+        [
+            "# valid for legacy cross-border work",
+            "# valid for management command",
+            "# valid for test usage",
+        ],
+    )
+    def test_with_comment(self, comment):
+        errors = results(self.FEATURE_FLAG_WITH_COMMENT.format(comment=comment))
+        assert errors == set()
+
+    @pytest.mark.parametrize(
+        "comment",
+        [
+            "# valid for something else",
+            " ",
+        ],
+    )
+    def test_with_invalid_comment(self, comment):
+        errors = results(self.FEATURE_FLAG_WITH_COMMENT.format(comment=comment))
+        assert errors == {
+            "2:0: ROU111 Disallow FeatureFlag creation in code",
+        }
 
 
 class TestVisitor:

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -638,7 +638,6 @@ FeatureFlag.objects.create(  {comment}
         [
             "# valid for legacy cross-border work",
             "# valid for management command",
-            "# valid for test usage",
         ],
     )
     def test_with_comment(self, comment):

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -536,6 +536,48 @@ class TestROU109:
         assert errors == {"4:12: ROU109 Disallow rename migrations"}
 
 
+class TestROU110:
+    SAVE_WITH_UPDATE_FIELDS = """from app.models import Model
+instance = Model(id="123", name="test")
+instance.save(update_fields=["id", "name"])
+"""
+
+    SAVE_WITHOUT_UPDATE_FIELDS = """from app.models import Model
+instance = Model(id="123", name="test")
+instance.save()
+instance.save(using="default")
+"""
+
+    SAVE_WITH_NEW_MODEL_SAVE_COMMENT = """from app.models import Model
+instance = Model(id="123", name="test")
+instance.save()  # new model save
+"""
+
+    SAVE_WITH_SERIALIZER_SAVE_COMMENT = """from app.models import Model
+instance = Model(id="123", name="test")
+instance.save()  # serializer save
+"""
+
+    def test_save_with_update_fields(self):
+        errors = results(self.SAVE_WITH_UPDATE_FIELDS)
+        assert errors == set()
+
+    def test_save_without_update_fields(self):
+        errors = results(self.SAVE_WITHOUT_UPDATE_FIELDS)
+        assert errors == {
+            "3:0: ROU110 Disallow .save() with no update_fields",
+            "4:0: ROU110 Disallow .save() with no update_fields",
+        }
+
+    def test_new_model_save_with_comment(self):
+        errors = results(self.SAVE_WITH_NEW_MODEL_SAVE_COMMENT)
+        assert errors == set()
+
+    def test_serializer_save_with_comment(self):
+        errors = results(self.SAVE_WITH_SERIALIZER_SAVE_COMMENT)
+        assert errors == set()
+
+
 class TestVisitor:
     def test_parse_to_string_warning(self):
         visitor = Visitor()


### PR DESCRIPTION
This PR adds a new lint rule `ROU110` for disallowing `.save()` without update fields or comments justifying it.