### PR TITLE
[DEV-15802] Linting rule for creating FeatureFlags in code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         pip install -r requirements-dev.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3.11
 
 
   - repo: https://github.com/pycqa/flake8

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Here is a list of the rules supported by this Flake8 plugin:
 * `ROU105` - Constants are not in order
 * `ROU106` - Relative imports are not allowed
 * `ROU107` - Inline function import is not at top of statement
+* `ROU108` - Import from model module instead of sub-packages
+* `ROU109` - Disallow rename migrations
+* `ROU111` - Disallow FeatureFlag creation in code
 
 ## Testing
 

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -1,6 +1,7 @@
 # Python imports
 import ast
 import importlib.metadata as importlib_metadata
+import re
 import tokenize
 import warnings
 from dataclasses import dataclass
@@ -33,6 +34,7 @@ ROU106 = "ROU106 Relative imports are not allowed"
 ROU107 = "ROU107 Inline function import is not at top of statement"
 ROU108 = "ROU108 Import from model module instead of sub-packages"
 ROU109 = "ROU109 Disallow rename migrations"
+ROU111 = "ROU111 Disallow FeatureFlag creation in code"
 
 
 @dataclass
@@ -178,6 +180,7 @@ class FileTokenHelper:
         self.lines_with_invalid_docstrings()
         self.lines_with_invalid_multi_line_strings()
         self.rename_migrations()
+        self.disallow_feature_flag_creation()
 
     def lines_with_blank_lines_after_comments(self) -> None:
         """
@@ -345,6 +348,34 @@ class FileTokenHelper:
             if disallowed_migration_text in line_token.line:
                 reported.add(line_token.start[0])
                 self.errors.append((*line_token.start, ROU109))
+
+    def disallow_feature_flag_creation(self) -> None:
+        """We can not create FeatureFlags in code, they are cached on the request."""
+        reported = set()
+        feature_flag_creation = re.compile(r".+(FeatureFlag\.objects\..*create)")
+        allowed_comments = [
+            "# valid for legacy cross-border work",
+            "# valid for management command",
+            "# valid for test usage",
+        ]
+
+        for line_token in self._file_tokens:
+            if line_token.start[0] in reported:
+                # There could be many tokens on a same line.
+                continue
+
+            line = line_token.line
+
+            if not feature_flag_creation.match(line):
+                # Skip lines that don't match
+                continue
+
+            if any(comment in line for comment in allowed_comments):
+                # Ignore lines with these comments, as they are valid
+                continue
+
+            reported.add(line_token.start[0])
+            self.errors.append((*line_token.start, ROU111))
 
 
 class Plugin:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py311']
 
 [tool.isort]
 case_sensitive = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = flake8_routable
-version = 0.1.2
+version = 0.1.3
 
 [options]
 py_modules = flake8_routable


### PR DESCRIPTION
In working through another feature, I found out that we were creating FeatureFlags in code. This isn't safe, because we store the value on first get of the flag, and could cause bad bugs. The 3 places we do this:
1. Tests - ok!
2. Django commands - ok! not cached
3. In cross-border self-serve - not ok! luckily the FF removal should be happening soon