### PR TITLE
Prevent .called_ prefix calls in mocks until we upgrade to python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Here is a list of the rules supported by this Flake8 plugin:
 * `ROU111` - Disallow FeatureFlag creation in code
 * `ROU112` - Tasks mush have *args, **kwargs
 * `ROU113` - Tasks can not have priority in the signature
+* `ROU114` - Prevent prefix "called_" for attributes of mock objects 
 
 ## Testing
 

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -38,6 +38,7 @@ ROU110 = "ROU110 Disallow .save() with no update_fields"
 ROU111 = "ROU111 Disallow FeatureFlag creation in code"
 ROU112 = "ROU112 Tasks mush have *args, **kwargs"
 ROU113 = "ROU113 Tasks can not have priority in the signature"
+# TODO: Remove ROU114 once we upgrade to python 3.12 since it's handled automatically
 ROU114 = "ROU114 prefix .called_ for attributes of mock objects"
 
 

--- a/flake8_routable.py
+++ b/flake8_routable.py
@@ -38,6 +38,7 @@ ROU110 = "ROU110 Disallow .save() with no update_fields"
 ROU111 = "ROU111 Disallow FeatureFlag creation in code"
 ROU112 = "ROU112 Tasks mush have *args, **kwargs"
 ROU113 = "ROU113 Tasks can not have priority in the signature"
+ROU114 = "ROU114 prefix .called_ for attributes of mock objects"
 
 
 @dataclass
@@ -183,6 +184,7 @@ class FileTokenHelper:
         self.lines_with_invalid_docstrings()
         self.lines_with_invalid_multi_line_strings()
         self.rename_migrations()
+        self.disallow_called_prefix_in_unit_tests()
         self.disallow_no_update_fields_save()
         self.disallow_feature_flag_creation()
         self.task_args_kwargs_and_priority()
@@ -353,6 +355,18 @@ class FileTokenHelper:
             if disallowed_migration_text in line_token.line:
                 reported.add(line_token.start[0])
                 self.errors.append((*line_token.start, ROU109))
+
+    def disallow_called_prefix_in_unit_tests(self) -> None:
+        """.called_, .has_calls, .not_called should not be called in mocks"""
+        reported = set()
+
+        for token in self._file_tokens:
+            token_str = token.string
+            if token.type == tokenize.NAME and (
+                token_str.startswith("called_") or token_str in {"has_calls", "not_called"}
+            ):
+                reported.add(token.start[0])
+                self.errors.append((*token.start, ROU114))
 
     def disallow_no_update_fields_save(self) -> None:
         """.save() must be called with update_fields."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = flake8_routable
-version = 0.1.6
+version = 0.1.7
 
 [options]
 py_modules = flake8_routable

--- a/tests/test_flake8_routable.py
+++ b/tests/test_flake8_routable.py
@@ -873,6 +873,16 @@ class TestROU113:
         assert errors == error
 
 
+class TestROU114:
+    def test_prefix_usage(self):
+        errors = results("something_mock.called_once_with(test)")
+        assert errors == {"1:15: ROU114 prefix .called_ for attributes of mock objects"}
+
+    def test_with_correct_prefix_usage(self):
+        errors = results("something_mock.assert_called_once_with(test)")
+        assert errors == set()
+
+
 class TestVisitor:
     def test_parse_to_string_warning(self):
         visitor = Visitor()


### PR DESCRIPTION
Adds rule to prevent `.called_ prefix, .has_calls, .not_called` to be called in mocks

This rule should be removed when we update to python 3.12 since it should be handled automatically. They included this in https://github.com/python/cpython/pull/100691